### PR TITLE
Popen(cmd, shell=True)

### DIFF
--- a/bgNukes.py
+++ b/bgNukes.py
@@ -94,7 +94,7 @@ def launch_nukes(nodes=[]):
         cmd = " ".join([nuke.env['ExecutablePath'], flags, '-F', '"' + instRange + '"', nuke.value("root.name"), '&>', logFile])
         print ">>> starting instance %d" % (i, )
         print "command: " + cmd
-        subprocess.Popen(cmd, shell=False)
+        subprocess.Popen(cmd, shell=True)
     
     nuke.message(str(inst) + ' renderers launched in the background.\nLog files: ' + ', '.join(logs))
     


### PR DESCRIPTION
Line 97: Popen(cmd, shell=True)

This script uses pip line, so  shell needs to be Ture. ( Actually shell=False didn't work in my environment, so I worked out this solution. )
